### PR TITLE
Always set alpha to 1 if no transition image

### DIFF
--- a/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/view/ImageViewerView.kt
+++ b/imageviewer/src/main/java/com/stfalcon/imageviewer/viewer/view/ImageViewerView.kt
@@ -187,6 +187,10 @@ class ImageViewerView<T> @JvmOverloads constructor(
     override fun setBackgroundColor(color: Int) {
         findViewById<View>(R.id.backgroundView).setBackgroundColor(color)
         setBackgroundColor = color
+        // Make sure background isn't transparent if there's no transition image.
+        if (externalTransitionImageView == null) {
+            findViewById<View>(R.id.backgroundView).alpha = 1f
+        }
     }
 
     fun disableGestureDetector() {


### PR DESCRIPTION
If a transition isn't being used, the background alpha will still be 0 when the first image is displayed.  Always set alpha to 1 for background color if the transition image view is null.